### PR TITLE
expand g:vsession_path defined by user

### DIFF
--- a/plugin/vsession.vim
+++ b/plugin/vsession.vim
@@ -9,8 +9,10 @@ endif
 
 let g:loaded_vsession = 1
 
-if !exists('g:vsession_path')
-	let g:vsession_path = expand('~/.vim/sessions')
+if exists('g:vsession_path')
+    let g:vsession_path = expand(g:vsession_path)
+el
+    let g:vsession_path = expand('~/.vim/sessions')
 endif
 
 if !isdirectory(g:vsession_path)


### PR DESCRIPTION
I configured vsession in dein.toml, following.

```toml
[[plugins]]
repos = 'skanehira/vsession'
hook_add = '''
    let g:vsession_path = '~/.config/nvim/sessions'
'''
```

Vsession don't make '/home/user/.config/nvim/sessions' but '\~/.config/nvim/sessions' directories on current directory.
This pull-request expand g:vsession_path defined by not only default but also user.

Thank you.