### PR TITLE
add support for auto saving last session when exiting vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ repo = 'skanehira/vsession'
 " default is ~/.vim/sessions.
 let g:vsession_path = '/to/your/path'
 
-" if installed fzf.vim, you can use fzf's interface to load and delete session.
-" default is false.
-let g:vsession_use_fzf = 1
+" default is 1
+let g:vsession_save_last_on_leave = 0
+
+" allowed values are 'quickpick' or 'fzf' or 'popup' or 'input'.
+let g:vsession_ui = 'quickpick'
 ```
 
 # Usage

--- a/doc/vsession.txt
+++ b/doc/vsession.txt
@@ -62,7 +62,6 @@ g:vsession_save_last_on_leave		        *g:vsession_save_last_on_leave*
 	default value: 1
 	Value indicating whether to auto save the last session on |VimLeave|.
 
-
 g:vsession_ui					*g:vsession_ui*
 	default value: 'quickpick'
 	allowed values: 'quickpick' or 'fzf' or 'popup' or 'input'

--- a/doc/vsession.txt
+++ b/doc/vsession.txt
@@ -58,6 +58,11 @@ VARIABLES					*vsession-variables*
 g:vsession_path					*g:vsession_path*
 	default value: "~/.vim/sessions"
 
+g:vsession_save_last_on_leave		        *g:vsession_save_last_on_leave*
+	default value: 1
+	Value indicating whether to auto save the last session on |VimLeave|.
+
+
 g:vsession_ui					*g:vsession_ui*
 	default value: 'quickpick'
 	allowed values: 'quickpick' or 'fzf' or 'popup' or 'input'


### PR DESCRIPTION
Once I load a session, I would like `vsession` to manage saving sessions without me remembering to save.

I have enabled `vsession_save_last_on_leave` by default and I'm ok to set it to `0` by default if that is what you prefer.